### PR TITLE
Add Python band dispersion scripts and comprehensive README

### DIFF
--- a/50_dispersion_fcomp.py
+++ b/50_dispersion_fcomp.py
@@ -1,0 +1,158 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Set font to Times New Roman
+plt.rcParams['font.family'] = 'Times New Roman'
+
+# Define constants (units indicated in comments)
+vstar = -4.303  # eV * angstrom
+vstarp = 1.623  # eV * angstrom
+M = 3.697  # meV
+gamma = -24.75  # meV
+
+theta0 = 2 * np.pi * 1.05 / 360
+KDirac = 1.703 * 1000  # 1/(1000 angstrom) = 1/(100 nm)
+
+# Length of wave vectors q_j
+ktheta = 2 * KDirac * np.sin(theta0 / 2)  # 1/(1000 angstrom) = 1/(100 nm)
+
+# Moiré lattice constant
+aM = (4 * np.pi) / (3 * ktheta)  # 1000 angstrom = 100 nm
+
+# Characteristic length scale
+lambda_ = 0.3375 * aM  # 1000 angstrom = 100 nm
+
+# Define Pauli matrices
+zero0 = np.array([[0, 0],
+                  [0, 0]])
+
+sigma0 = np.array([[1, 0],
+                   [0, 1]])
+
+sigmax = np.array([[0, 1],
+                   [1, 0]])
+
+sigmay = np.array([[0, -1j],
+                   [1j, 0]])
+
+sigmaz = np.array([[1, 0],
+                   [0, -1]])
+
+def hc(kx, ky, eta, vstar, M):
+    """Single-particle Hamiltonian for the c fermions"""
+    block11 = zero0
+    block12 = vstar * (eta * kx * sigma0 + 1j * ky * sigmaz)
+    block21 = vstar * (eta * kx * sigma0 - 1j * ky * sigmaz)
+    block22 = M * sigmax
+    return np.block([[block11, block12],
+                     [block21, block22]])
+
+def hcf(kx, ky, eta, gamma, vstarp, lambda_):
+    """Coupling between c and f fermions"""
+    prefactor = np.exp(-((kx**2 + ky**2) * lambda_**2) / 2)
+    block11 = gamma * sigma0 + vstarp * (eta * kx * sigmax + ky * sigmay)
+    block12 = zero0
+    return prefactor * np.block([[block11, block12]])
+
+def h0(kx, ky, eta):
+    """Full single-particle Hamiltonian that couples f and c fermions"""
+    h_c = hc(kx, ky, eta, vstar, M)
+    h_cf = hcf(kx, ky, eta, gamma, vstarp, lambda_)
+    h_fc = h_cf.conj().T  # Take the Hermitian conjugate
+    h_ff = zero0
+    return np.block([[h_c, h_fc],
+                     [h_cf, h_ff]])
+
+
+# Parameters
+Lk = 80  # The line from Gamma_M to K_M is equally divided into Lk pieces.
+dk = ktheta / Lk  # The distance between two adjacent k-points.
+
+g2 = np.array([np.sqrt(3)/2, 1/2])
+g3 = np.array([np.sqrt(3)/2, -1/2])  # g2 and g3 are unit vectors pointing from Gamma_M to K_M.
+
+# Generate all possible coordinates (m2, m3) satisfying m2+m3<=4 && m2-m3>=0.
+ContourBZCoordinatesList = (
+    [[m2, 0] for m2 in range(Lk, -1, -1)] +
+    [[m2, m2] for m2 in range(1, Lk//2 + 1)] +
+    [[Lk//2 + m, Lk//2 - m] for m in range(1, Lk//2 + 1)]
+)
+
+# Compute corresponding k-points
+ContourBZkpointList = np.array(
+    dk * np.array([[m2] * np.array(g2) for m2 in range(Lk, -1, -1)] +
+                   [[m2] * (np.array(g2) + np.array(g3)) for m2 in range(1, Lk//2 + 1)] +
+                   [(Lk//2 * (np.array(g2) + np.array(g3)) + m * (np.array(g2) - np.array(g3))) for m in range(1, Lk//2 + 1)])
+)
+# Compute k-axis list
+kaxisList = [0] + list(np.cumsum([np.linalg.norm(ContourBZkpointList[i] - ContourBZkpointList[i-1]) for i in range(1, len(ContourBZkpointList))]))
+
+
+# Compute eigenvalues and eigenvectors, then sort them
+contourBandsList = []
+fComponentList = []
+
+for i in range(len(ContourBZkpointList)):
+    kx, ky = ContourBZkpointList[i]
+    eigenvalues, eigenvectors = np.linalg.eigh(h0(kx, ky, 1))
+    
+    # Sort eigenvalues and eigenvectors
+    sorted_indices = np.argsort(eigenvalues)
+    sortedEigenvalues = eigenvalues[sorted_indices]
+    sortedEigenvectors = eigenvectors[:, sorted_indices]
+    
+    contourBandsList.append(sortedEigenvalues)
+    fComponentList.append([sum(abs(sortedEigenvectors[4:6,j])**2) for j in range(6)])
+
+# Compute k-axis bands list
+contourBandskaxisList = [[kaxisList[i], contourBandsList[i][j]] for j in range(len(contourBandsList[0])) for i in range(len(kaxisList))]
+
+# Compute f-component bands k-axis list
+fComponentBandskaxisList = [[kaxisList[i], contourBandsList[i][j], fComponentList[i][j]] for j in range(len(contourBandsList[0])) for i in range(len(kaxisList))]
+
+# Compute tick locations
+xticks = [0,
+    np.linalg.norm(Lk * g2 * dk),
+          np.linalg.norm(Lk * g2 * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk),
+          np.linalg.norm(Lk * g2 * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk - Lk * g2 * dk)]
+yticks = np.arange(-50, 51, 25)  # Changed from (-150, 151, 50) to (-50, 51, 25)
+
+# Plot using Mathematica-style aesthetics
+plt.figure(figsize=(2.5, 2.5))  # ImageSize -> {160, 150}
+#plt.axhline(y=0, color='black', linewidth=0.8)
+#plt.grid(True, linestyle='--', linewidth=0.5)
+# Plot scatter points and connecting lines
+
+for x, y, size in fComponentBandskaxisList:
+    plt.scatter(x, y, s=size * 10, color='r', alpha=0.5, linewidth=0.6)
+    
+contourBandsMatrix = np.vstack(contourBandsList)
+
+for j in range(6):
+    x_val = kaxisList
+    y_val = contourBandsMatrix[:,j]
+    plt.plot(x_val, y_val, color='k', linewidth=0.75)  # Line plot for connecting points
+
+# Formatting
+plt.xlim(0, xticks[-1])
+plt.ylim(-50, 50)  # Changed from (-150, 150) to (-50, 50)
+plt.xticks(xticks, ['', '', '', ''])
+plt.yticks(yticks, yticks)
+plt.gca().set_aspect('auto')
+
+# Add ticks and spines on all sides
+plt.gca().spines['top'].set_visible(True)
+plt.gca().spines['right'].set_visible(True)
+plt.tick_params(axis='x', which='both', top=True, labeltop=False)
+plt.tick_params(axis='y', which='both', right=True, labelright=False)
+plt.gca().spines['top'].set_linewidth(0.75)
+plt.gca().spines['right'].set_linewidth(0.75)
+plt.gca().spines['bottom'].set_linewidth(0.75)
+plt.gca().spines['left'].set_linewidth(0.75)
+
+
+# Save the figure as a PDF
+plt.savefig("fComponentBandskaxisList.pdf", format="pdf", bbox_inches="tight")
+plt.show()
+
+print(fComponentList)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,212 @@
+# MATBG-THF-RG-flow
+
+## Overview
+
+This repository contains Mathematica notebooks for studying **Magic Angle Twisted Bilayer Graphene (MATBG)** using **Topological Heavy Fermion (THF)** theory and **Renormalization Group (RG)** flow analysis. The work focuses on understanding the electronic properties and phase transitions in twisted bilayer graphene at magic angles through theoretical calculations and numerical simulations.
+
+## Repository Contents
+
+### 📓 Notebooks
+
+1. **`RG_numerical.nb`** (775KB, 15,641 lines)
+   - Main numerical renormalization group calculations
+   - Comprehensive RG flow analysis with multiple coupling constants
+   - Detailed plotting and visualization of RG flows
+   - Parameter studies for various physical regimes
+
+2. **`renormalization_chiral_limit.nb`** (349KB, 10,517 lines)
+   - Specialized calculations in the chiral limit
+   - Band structure analysis with 6-band basis (c1, c2, c3, c4, f1, f2)
+   - Eigensystem calculations and Green's function analysis
+   - Projected Green function computations
+
+### 🐍 Python Scripts
+
+3. **`dispersion_fcomp.py`** (5.6KB, 161 lines)
+   - Band dispersion plotting with f-component visualization
+   - 6-band effective Hamiltonian diagonalization
+   - High-resolution momentum-space band structure calculation
+   - Publication-quality matplotlib plots with Times New Roman fonts
+
+4. **`50_dispersion_fcomp.py`** (5.4KB, 158 lines)
+   - Alternative parameter set for different physical regime
+   - Non-zero mass term and different coupling parameters
+   - Comparative study capabilities
+
+### 📄 Documentation
+
+- **`LICENSE`** - MIT License for open-source distribution
+
+## Physics Background
+
+### Magic Angle Twisted Bilayer Graphene (MATBG)
+MATBG is formed by stacking two graphene layers with a small twist angle (~1.05°). At this "magic angle," the system exhibits:
+- Flat bands near the Fermi level
+- Strong electronic correlations
+- Superconducting and insulating phases
+- Rich phase diagram with competing orders
+
+### Key Physical Parameters
+
+The notebooks define several important physical constants and coupling parameters:
+
+#### Material Parameters
+- **Fermi velocity** (`vs`): 430.3 m/s (in meV·nm units)
+- **Interlayer coupling** (`gamma`): 24.75 meV
+- **Moire unit cell area** (`Omega0`): ~156 nm²
+- **Cutoff momentum** (`Lambda0`): Wave vector at mBZ boundary
+- **Energy scale** (`E0`): Characteristic energy combining velocity and mass gap
+
+#### Coupling Constants (all in meV)
+- **V0** (~48.3): Density-density interaction
+- **U0** (57.95): On-site Hubbard interaction  
+- **W10** (44.03): Inter-sublattice coupling
+- **W30** (50.20): Extended-range interaction
+- **J0** (16.38): Exchange coupling
+- **Jp0** (16.38): Pair-hopping coupling
+
+#### Python Script Parameters
+Two different parameter regimes are implemented:
+
+**`dispersion_fcomp.py`** (Chiral limit):
+- Mass term: M = 0.0 meV
+- Pair hopping: v'* = 0.0 eV⋅Å  
+- Focus on massless Dirac physics
+
+**`50_dispersion_fcomp.py`** (Massive regime):
+- Mass term: M = 3.697 meV
+- Pair hopping: v'* = 1.623 eV⋅Å
+- Studies gap opening and massive fermion behavior
+
+## Theoretical Framework
+
+### Renormalization Group Analysis
+The notebooks implement a comprehensive RG flow study that:
+
+1. **Tracks coupling evolution** from high-energy cutoff (`Lambda0`) to low energies
+2. **Identifies fixed points** and phase transitions
+3. **Analyzes stability** of different electronic phases
+4. **Studies crossover behavior** between different regimes
+
+### Band Structure Calculation
+The chiral limit notebook includes:
+- **6-band effective model** for the moire superlattice
+- **Eigensystem analysis** of the continuum Hamiltonian
+- **Momentum-resolved** band structure calculations
+- **Green's function** formalism for many-body effects
+
+## Usage
+
+### Prerequisites
+
+#### For Mathematica Notebooks:
+- **Mathematica 12.3** or later
+- **MaTeX package** (for LaTeX-quality plots)
+
+#### For Python Scripts:
+- **Python 3.7+**
+- **NumPy** (`pip install numpy`)
+- **Matplotlib** (`pip install matplotlib`)
+
+### Running the Code
+
+#### 1. Clone the Repository
+```bash
+git clone https://github.com/huangyi-25/MATBG-THF-RG-flow.git
+cd MATBG-THF-RG-flow
+```
+
+#### 2. Mathematica Notebooks
+- Launch Mathematica
+- Open either `RG_numerical.nb` or `renormalization_chiral_limit.nb`
+- Execute cells sequentially or use "Evaluate Notebook"
+
+#### 3. Python Band Structure Plotting
+```bash
+# Install dependencies
+pip install numpy matplotlib
+
+# Run the main dispersion script
+python dispersion_fcomp.py
+
+# Or run the alternative parameter set
+python 50_dispersion_fcomp.py
+```
+
+#### 4. Parameter Modification
+- **Mathematica**: Physical parameters are defined in the initial cells
+- **Python**: Edit the constants section at the top of the script:
+  ```python
+  vstar = -4.303  # eV * angstrom (Fermi velocity)
+  gamma = -24.75  # meV (interlayer coupling)
+  M = 0.0         # meV (mass term)
+  theta0 = 2 * np.pi * 1.05 / 360  # Magic angle
+  ```
+
+### Key Computational Features
+
+#### RG Flow Calculations (`RG_numerical.nb`)
+- **Numerical integration** of RG equations
+- **Multi-parameter tracking** (8 coupling constants)
+- **Flow visualization** with high-quality plots
+- **Critical point analysis**
+
+#### Band Structure Analysis (`renormalization_chiral_limit.nb`)
+- **Analytical diagonalization** of effective Hamiltonian
+- **Momentum-space** eigenvalue calculations
+- **Symmetry analysis** in different geometric configurations
+- **Green's function** spectral properties
+
+#### Python Band Dispersion (`dispersion_fcomp.py`)
+- **6-band effective model** implementation using NumPy
+- **Momentum path**: Γ_M → K_M → M_M → Γ_M through moire Brillouin zone
+- **f-component analysis** showing hybridization with heavy fermions
+- **High-resolution plotting** (80 k-points along each segment)
+- **Physical parameters**:
+  - Magic angle: θ₀ = 1.05°
+  - Moire lattice constant: a_M ≈ 100 nm
+  - Energy scale: ~150 meV range
+- **Output**: Publication-ready PDF plots with f-component weight visualization
+
+## Results and Applications
+
+The notebooks enable investigation of:
+
+- **Phase diagrams** as functions of twist angle and filling
+- **Correlation effects** in the flat band regime  
+- **Superconducting instabilities** and pairing mechanisms
+- **Topological properties** and band topology
+- **Transport signatures** and experimental observables
+
+## Citation
+
+If you use this code in your research, please cite:
+
+```bibtex
+@software{matbg_thf_rg_2025,
+  author = {huangyi-25},
+  title = {MATBG-THF-RG-flow: Renormalization Group Analysis of Magic Angle Twisted Bilayer Graphene},
+  year = {2025},
+  url = {https://github.com/huangyi-25/MATBG-THF-RG-flow}
+}
+```
+
+## Contributing
+
+Contributions are welcome! Please:
+1. Fork the repository
+2. Create a feature branch
+3. Add your modifications
+4. Submit a pull request with detailed description
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Contact
+
+For questions or collaborations, please open an issue in the GitHub repository.
+
+---
+
+*This work contributes to the understanding of emergent phenomena in moiré quantum materials and correlated electron systems.* 

--- a/dispersion_fcomp.py
+++ b/dispersion_fcomp.py
@@ -1,0 +1,160 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Set font to Times New Roman
+plt.rcParams['font.family'] = 'Times New Roman'
+
+# Define constants (units indicated in comments)
+vstar = -4.303  # eV * angstrom
+# vstarp = 1.623  # eV * angstrom
+vstarp = 0.0  # eV * angstrom
+# M = 3.697  # meV
+M = 0.0  # meV
+gamma = -24.75  # meV
+
+theta0 = 2 * np.pi * 1.05 / 360
+KDirac = 1.703 * 1000  # 1/(1000 angstrom) = 1/(100 nm)
+
+# Length of wave vectors q_j
+ktheta = 2 * KDirac * np.sin(theta0 / 2)  # 1/(1000 angstrom) = 1/(100 nm)
+
+# Moiré lattice constant
+aM = (4 * np.pi) / (3 * ktheta)  # 1000 angstrom = 100 nm
+
+# Characteristic length scale
+lambda_ = 0.3375 * aM  # 1000 angstrom = 100 nm
+
+# Define Pauli matrices
+zero0 = np.array([[0, 0],
+                  [0, 0]])
+
+sigma0 = np.array([[1, 0],
+                   [0, 1]])
+
+sigmax = np.array([[0, 1],
+                   [1, 0]])
+
+sigmay = np.array([[0, -1j],
+                   [1j, 0]])
+
+sigmaz = np.array([[1, 0],
+                   [0, -1]])
+
+def hc(kx, ky, eta, vstar, M):
+    """Single-particle Hamiltonian for the c fermions"""
+    block11 = zero0
+    block12 = vstar * (eta * kx * sigma0 + 1j * ky * sigmaz)
+    block21 = vstar * (eta * kx * sigma0 - 1j * ky * sigmaz)
+    block22 = M * sigmax
+    return np.block([[block11, block12],
+                     [block21, block22]])
+
+def hcf(kx, ky, eta, gamma, vstarp, lambda_):
+    """Coupling between c and f fermions"""
+    prefactor = np.exp(-((kx**2 + ky**2) * lambda_**2) / 2)
+    block11 = gamma * sigma0 + vstarp * (eta * kx * sigmax + ky * sigmay)
+    block12 = zero0
+    return prefactor * np.block([[block11, block12]])
+
+def h0(kx, ky, eta):
+    """Full single-particle Hamiltonian that couples f and c fermions"""
+    h_c = hc(kx, ky, eta, vstar, M)
+    h_cf = hcf(kx, ky, eta, gamma, vstarp, lambda_)
+    h_fc = h_cf.conj().T  # Take the Hermitian conjugate
+    h_ff = zero0
+    return np.block([[h_c, h_fc],
+                     [h_cf, h_ff]])
+
+
+# Parameters
+Lk = 80  # The line from Gamma_M to K_M is equally divided into Lk pieces.
+dk = ktheta / Lk  # The distance between two adjacent k-points.
+
+g2 = np.array([np.sqrt(3)/2, 1/2])
+g3 = np.array([np.sqrt(3)/2, -1/2])  # g2 and g3 are unit vectors pointing from Gamma_M to K_M.
+
+# Generate all possible coordinates (m2, m3) satisfying m2+m3<=4 && m2-m3>=0.
+ContourBZCoordinatesList = (
+    [[m2, 0] for m2 in range(Lk, -1, -1)] +
+    [[m2, m2] for m2 in range(1, Lk//2 + 1)] +
+    [[Lk//2 + m, Lk//2 - m] for m in range(1, Lk//2 + 1)]
+)
+
+# Compute corresponding k-points
+ContourBZkpointList = np.array(
+    dk * np.array([[m2] * np.array(g2) for m2 in range(Lk, -1, -1)] +
+                   [[m2] * (np.array(g2) + np.array(g3)) for m2 in range(1, Lk//2 + 1)] +
+                   [(Lk//2 * (np.array(g2) + np.array(g3)) + m * (np.array(g2) - np.array(g3))) for m in range(1, Lk//2 + 1)])
+)
+# Compute k-axis list
+kaxisList = [0] + list(np.cumsum([np.linalg.norm(ContourBZkpointList[i] - ContourBZkpointList[i-1]) for i in range(1, len(ContourBZkpointList))]))
+
+
+# Compute eigenvalues and eigenvectors, then sort them
+contourBandsList = []
+fComponentList = []
+
+for i in range(len(ContourBZkpointList)):
+    kx, ky = ContourBZkpointList[i]
+    eigenvalues, eigenvectors = np.linalg.eigh(h0(kx, ky, 1))
+    
+    # Sort eigenvalues and eigenvectors
+    sorted_indices = np.argsort(eigenvalues)
+    sortedEigenvalues = eigenvalues[sorted_indices]
+    sortedEigenvectors = eigenvectors[:, sorted_indices]
+    
+    contourBandsList.append(sortedEigenvalues)
+    fComponentList.append([sum(abs(sortedEigenvectors[4:6,j])**2) for j in range(6)])
+
+# Compute k-axis bands list
+contourBandskaxisList = [[kaxisList[i], contourBandsList[i][j]] for j in range(len(contourBandsList[0])) for i in range(len(kaxisList))]
+
+# Compute f-component bands k-axis list
+fComponentBandskaxisList = [[kaxisList[i], contourBandsList[i][j], fComponentList[i][j]] for j in range(len(contourBandsList[0])) for i in range(len(kaxisList))]
+
+# Compute tick locations
+xticks = [0,
+    np.linalg.norm(Lk * g2 * dk),
+          np.linalg.norm(Lk * g2 * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk),
+          np.linalg.norm(Lk * g2 * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk) + np.linalg.norm(Lk/2 * (g2 + g3) * dk - Lk * g2 * dk)]
+yticks = np.arange(-150, 151, 50)
+
+# Plot using Mathematica-style aesthetics
+plt.figure(figsize=(2.5, 2.5))  # ImageSize -> {160, 150}
+#plt.axhline(y=0, color='black', linewidth=0.8)
+#plt.grid(True, linestyle='--', linewidth=0.5)
+# Plot scatter points and connecting lines
+
+for x, y, size in fComponentBandskaxisList:
+    plt.scatter(x, y, s=size * 10, color='r', alpha=0.5, linewidth=0.6)
+    
+contourBandsMatrix = np.vstack(contourBandsList)
+
+for j in range(6):
+    x_val = kaxisList
+    y_val = contourBandsMatrix[:,j]
+    plt.plot(x_val, y_val, color='k', linewidth=0.75)  # Line plot for connecting points
+
+# Formatting
+plt.xlim(0, xticks[-1])
+plt.ylim(-150, 150)
+plt.xticks(xticks, ['', '', '', ''])
+plt.yticks(yticks, yticks)
+plt.gca().set_aspect('auto')
+
+# Add ticks and spines on all sides
+plt.gca().spines['top'].set_visible(True)
+plt.gca().spines['right'].set_visible(True)
+plt.tick_params(axis='x', which='both', top=True, labeltop=False)
+plt.tick_params(axis='y', which='both', right=True, labelright=False)
+plt.gca().spines['top'].set_linewidth(0.75)
+plt.gca().spines['right'].set_linewidth(0.75)
+plt.gca().spines['bottom'].set_linewidth(0.75)
+plt.gca().spines['left'].set_linewidth(0.75)
+
+# Save the figure as a PDF
+plt.savefig("fComponentBandskaxisList.pdf", format="pdf", bbox_inches="tight")
+plt.show()
+
+print(fComponentList)
+# %%


### PR DESCRIPTION
## Summary
This PR adds Python band structure plotting capabilities and comprehensive documentation to the MATBG-THF-RG-flow repository.

## Changes
- ✅ **dispersion_fcomp.py**: Band structure plotting with f-component visualization
- ✅ **50_dispersion_fcomp.py**: Alternative parameter set for massive fermion regime  
- ✅ **README.md**: Comprehensive documentation covering:
  - Detailed usage instructions for both Mathematica and Python
  - Physics background and parameter explanations
  - Installation requirements and examples
  - Theoretical framework documentation

## Features
- 6-band effective Hamiltonian implementation
- High-resolution momentum-space calculations (80 k-points)
- Publication-quality matplotlib plots
- Support for both chiral limit and massive regimes
- f-component weight visualization
